### PR TITLE
Remove Python 3.4 as a preparation for Fedora 33

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ script:
 matrix:
   include:
   - env: TOXENV=py27
-  - env: TOXENV=py34
   - env: TOXENV=py35
   - env: TOXENV=py36
   - env: TOXENV=py37

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,6 @@ matrix:
   - env: TOXENV=py37
   - env: TOXENV=py38
   - env: TOXENV=py39
+  - env: TOXENV=py310
   - env: TOXENV=pypy
   - env: TOXENV=pypy3

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35,py36,py37,py38,py39,pypy,pypy3
+envlist = py27,py35,py36,py37,py38,py39,py310,pypy,pypy3
 skipsdist = True
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36,py37,py38,py39,pypy,pypy3
+envlist = py27,py35,py36,py37,py38,py39,pypy,pypy3
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
See https://fedoraproject.org/wiki/Changes/RetirePython34