### PR TITLE
Pypy 3.7 is no longer available in Fedora 37

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ matrix:
   - env: TOXENV=py39
   - env: TOXENV=py310
   - env: TOXENV=py311
+  - env: TOXENV=py312
   - env: TOXENV=pypy
   - env: TOXENV=pypy38
   - env: TOXENV=pypy39

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py36,py37,py38,py39,py310,py311,pypy,pypy38,pypy39
+envlist = py27,py36,py37,py38,py39,py310,py311,py312,pypy,pypy38,pypy39
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
+ add Python 3.12